### PR TITLE
docs: update API base path references from /api/v1 to /v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ References: `references/doctrine/interaction_language.md`, `references/doctrine/
 - Design: thin client, no sensitive token storage in browser, cookie-based auth, version-bound API usage
 
 ### API
-- Versioned under `/api/v1`
+- Versioned under `/v1`
 - Breaking changes require version bump
 - OpenAPI contract reviewed before release — treated as a public boundary
 - No silent breaking changes

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ High-level structure:
 
 Browser Client  
 ↓  
-Versioned API (`/api/v1`)  
+Versioned API (`/v1`)  
 ↓  
 Domain Layer  
 ↓  
@@ -100,7 +100,7 @@ Deployment is reproducible via Docker.
 
 ## API Governance
 
-- Versioned under `/api/v1`
+- Versioned under `/v1`
 - Breaking changes require version bump
 - OpenAPI contract reviewed before release
 - No silent breaking changes

--- a/adr/ADR-005-api-versioning-and-contract-strategy.md
+++ b/adr/ADR-005-api-versioning-and-contract-strategy.md
@@ -5,7 +5,7 @@ PiggyPulse exposes a versioned REST API consumed by its own SPA frontend and pot
 
 ## Decision
 Adopt the following API versioning and contract strategy:
-- **Versioning scheme:** URI path prefix (`/api/v1`, `/api/v2`, …)
+- **Versioning scheme:** URI path prefix (`/v1`, `/v2`, …)
 - **Breaking‑change policy:** Breaking changes require a major version bump; no silent breaking changes
 - **Contract format:** OpenAPI 3.x, generated code‑first from Rocket route definitions via `rocket_okapi`
 - **Contract review:** OpenAPI spec reviewed before release — treated as a public boundary


### PR DESCRIPTION
## Summary

- Update `README.md` architecture diagram and API governance section
- Update `AGENTS.md` API versioning reference
- Update `ADR-005` versioning scheme examples

The API is served at `api.piggy-pulse.com`, making the `/api` prefix in the path redundant.

## Test plan

- [ ] Review that all docs accurately reflect the new `/v1` base path

🤖 Generated with [Claude Code](https://claude.com/claude-code)