### PR TITLE
docs: add encryption-at-rest documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ All product specs, wireframes, and HTML mocks live in `designs/`. This is the ca
 - Product doctrine: `references/doctrine/` (interaction language, governance, keyboard nav, design decisions)
 - Agent role contracts: `references/agents/`
 - Figma tokens/components: `references/figma/`
-- Architecture decisions: `adr/`
+- Architecture decisions: `adr/` (see [ADR-010](adr/ADR-010-encryption-at-rest.md) for encryption at rest)
 - Product alignment: `piggypulse_product_alignment_docs/`
 
 **Before generating any UI, spec, or wireframe — read `designs/v1/design-system.md` and the relevant feature spec.**
@@ -56,6 +56,7 @@ References: `references/doctrine/interaction_language.md`, `references/doctrine/
 - Framework: Rocket
 - Database: PostgreSQL + SQLx
 - Auth: HttpOnly cookie sessions, Argon2 hashing, optional 2FA
+- Encryption: Per-user AES-256-GCM encryption at rest; DEK/KEK key hierarchy; client-side encryption in web and iOS
 - Design: explicit DTO separation, compile-time guarantees, SQL transparency, stateless requests
 
 ### Frontend (`piggy-pulse-web`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,32 @@ Design characteristics:
 
 ---
 
+## Encryption Layer
+
+PiggyPulse encrypts all user financial data at rest using per-user AES-256-GCM keys:
+
+- Each user has a unique Data Encryption Key (DEK)
+- The DEK is wrapped (encrypted) with a Key Encryption Key derived from the user's password via Argon2id
+- The plaintext DEK is never stored on disk — it exists in client memory and, after login, in a server-side per-session store
+- Both web and iOS clients implement the full client-side encryption/decryption stack
+- Encrypted columns span seven database tables (transactions, accounts, categories, vendors, budgets, subscriptions)
+
+For the full design, see [ADR-010: Encryption at Rest](adr/ADR-010-encryption-at-rest.md).
+
+```
+Browser Client  or  iOS Client
+↓
+AES-256-GCM encrypt/decrypt (client-side)
+↓
+Versioned API (`/v1`)
+↓
+Domain Layer
+↓
+Encrypted PostgreSQL
+```
+
+---
+
 ## Documentation
 
 OpenAPI specification is generated at runtime and consumed by a statically hosted Swagger UI.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Key properties:
 - HttpOnly cookie-based authentication
 - CSRF protection
 - Argon2 password hashing
+- Encryption at rest (AES-256-GCM with per-user keys)
 - DTO separation between internal models and external contracts
 - Stateless API design
 - OpenAPI as a first-class artifact
@@ -63,6 +64,7 @@ Authentication model:
 
 - HttpOnly session cookies
 - No tokens stored in localStorage
+- All user financial data encrypted at rest
 - Backend validation on every request
 - Rate limiting on sensitive endpoints
 - Optional 2FA support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,6 +95,28 @@ This reduces the impact of client-side script compromise by keeping credentials 
 
 ---
 
+## Encryption at Rest
+
+PiggyPulse encrypts all user financial data at rest — transaction amounts and descriptions, account balances, category and vendor metadata, subscription billing amounts, and budget targets.
+
+### Design
+
+- **Per-user key hierarchy:** Each user has a 32-byte Data Encryption Key (DEK) generated from a CSPRNG at signup. The DEK is wrapped (encrypted) with a Key Encryption Key (KEK) derived from the user's password via Argon2id. The wrapped DEK is stored on the server; the plaintext DEK exists only in client memory and, after login, in a server-side per-session store.
+- **Algorithm:** AES-256-GCM with 96-bit nonce and 128-bit authentication tag.
+- **Scope:** All user-data columns are encrypted across seven tables — `transaction`, `logical_transaction_state`, `account`, `category`, `vendor`, `budget_category`, and `subscription`.
+- **Unlock flow:** After login, the client receives the wrapped DEK and Argon2id parameters, derives the KEK locally, unwraps the DEK, and POSTs it to `POST /v2/auth/unlock`. The server holds the DEK in an in-process session store keyed by the session or API token. On logout, the DEK is evicted.
+- **Key protection:** The `Dek` Rust type zeroizes on drop, omits `Debug`, `Serialize`, `Clone`, and `Display` derives. Only an explicitly named `clone_for_request()` method may copy the key.
+- **Client-side encryption:** Both the web app (React/TypeScript) and iOS client implement the full encryption stack — Argon2id KEK derivation, DEK unwrap, AES-256-GCM encryption and decryption of server data.
+
+### What encryption does not protect against
+
+- **Malware on the client device:** Once data is decrypted in the browser or app, it is accessible to that process and any attacker with local access.
+- **Server-side active tampering:** A compromised server process with write access to the session store could read a user's DEK while that user has an active session.
+
+For a complete design reference, see [ADR-010: Encryption at Rest](adr/ADR-010-encryption-at-rest.md).
+
+---
+
 ## Password Hashing
 
 - Passwords are hashed using Argon2 with per-user salts and memory-hard parameters

--- a/adr/ADR-010-encryption-at-rest.md
+++ b/adr/ADR-010-encryption-at-rest.md
@@ -1,0 +1,73 @@
+# ADR-010: Encryption at Rest
+
+## Context
+
+PiggyPulse stores sensitive financial data: transaction amounts and descriptions, account balances, category names, vendor names, subscription billing amounts, and budget targets. A server-side breach or database compromise would expose this data if stored in plaintext.
+
+The platform already protects data in transit (HTTPS/TLS), authenticates users (Argon2 password hashing, HttpOnly session cookies, Bearer tokens), and supports optional 2FA. However, none of these defences protect the data at the storage layer. If an attacker gains read access to the PostgreSQL database — through a SQL injection vulnerability, a compromised backup, or an infrastructure-level breach — all user financial data would be readable.
+
+Encryption at rest ensures that data on disk is ciphertext, not plaintext. Decryption requires a per-user Data Encryption Key (DEK) that is not stored on the server in usable form.
+
+## Decision
+
+- **Algorithm:** AES-256-GCM (AES-GCM with 256-bit key, 96-bit nonce, 128-bit authentication tag).
+- **Key hierarchy:**
+  - Each user has a 32-byte DEK (Data Encryption Key) generated from a CSPRNG at signup.
+  - The DEK is wrapped (encrypted) using a KEK (Key Encryption Key) derived from the user's password via Argon2id.
+  - The wrapped DEK (`wrapped_dek`) and wrap parameters (`dek_wrap_params` — Argon2id salt/costs + AES-GCM wrap nonce) are stored on the server alongside the user record.
+  - The plaintext DEK is held only in client memory between unwrap and upload, and in a server-side per-session store for the lifetime of the authenticated session.
+- **DEK transport:**
+  - After login, the client receives `wrapped_dek` and `dek_wrap_params` in the login response.
+  - The client derives the KEK locally via Argon2id(password, salt), unwraps the DEK, and POSTs the plaintext DEK (base64-encoded) to `POST /v2/auth/unlock`.
+  - The server stores the DEK in an in-process session store (`SessionDekStore`) keyed by the session or API token principal ID.
+  - On logout or session expiry, the DEK is removed from the session store.
+- **Encryption scope:** All user-data columns across these tables are encrypted:
+
+  | Table | Encrypted columns |
+  |---|---|
+  | `transaction` | `amount_enc`, `description_enc` |
+  | `logical_transaction_state` | `current_sum_enc` |
+  | `account` | `current_balance_enc`, `name_enc`, `color_enc`, `icon_enc`, `spend_limit_enc`, `next_transfer_amount_enc`, `top_up_amount_enc` |
+  | `category` | `name_enc`, `color_enc`, `icon_enc`, `description_enc` |
+  | `vendor` | `name_enc`, `description_enc` |
+  | `budget_category` | `budgeted_value_enc` |
+  | `subscription` | `name_enc`, `billing_amount_enc` |
+
+- **Client-side encryption:** Both the web app (React/TypeScript) and iOS client implement the full encryption stack — Argon2id KEK derivation, DEK unwrap, AES-256-GCM encrypt/decrypt of server responses. This means sensitive data is encrypted before it reaches the database and decrypted only in the client.
+- **Key protection:** The `Dek` Rust type zeroizes on drop, omits `Debug`, `Serialize`, `Clone`, and `Display` derives. The only sanctioned copy path is `clone_for_request()`, with a deliberately awkward name to discourage casual use.
+
+## Alternatives Considered
+
+- **PostgreSQL `pgcrypto` extension:** Would encrypt at the database level but would not protect against a server-side process with DB read access. The key would still live on the server, reducing the security model to "trust the server process."
+- **Application-level encryption with server-held key:** Simpler to implement (single key stored in an env var or HSM), but a server compromise would expose all users' data. Per-user keys raise the cost of a mass breach.
+- **Cloud KMS (AWS KMS, GCP Cloud KMS):** Would provide managed key storage and rotation, but introduces cloud dependency, adds latency to every read/write, and complicates the self-hosted deployment story.
+- **Transparent Data Encryption (TDE):** Encrypts the entire database at the filesystem or block level. Protects against stolen disks or backups but not against a live DB read query from a compromised application process.
+
+## Consequences
+
+### Positive
+- **Defence in depth:** Even with full database read access, an attacker cannot recover plaintext financial data without each user's password.
+- **Client-side trust model:** The server never holds the plaintext DEK in persistent storage — only in per-session memory.
+- **User-controlled key material:** The DEK is derived from the user's password; changing the password re-wraps the DEK under a new KEK.
+- **Open source verification:** The encryption implementation is fully visible in the API, web, and iOS repositories.
+
+### Negative
+- **No server-side aggregation:** The ledger refactor's materialized aggregate tables (`user_daily_totals`, `category_all_time`, etc.) were dropped because the server can no longer sum ciphertext. Dashboard aggregates are computed client-side.
+- **Increased login complexity:** Users must complete the unlock flow after login (DEK unwrap + POST). This adds a step to the authentication sequence.
+- **No DB-level uniqueness enforcement:** Unique constraints on encrypted columns (e.g. `account_user_id_name_key`) were dropped because AES-GCM produces different ciphertext per encryption. Uniqueness is enforced in the service layer by decrypting existing names.
+- **Session store is in-process (v1):** The current `SessionDekStore` uses an in-process `HashMap`. A server restart or horizontal scale-out would lose all session DEKs, requiring clients to re-unlock. A Redis-backed store is planned for Phase 5.
+- **Performance overhead:** Every write encrypts and every read decrypts the encrypted fields. For a single-user or small-scale deployment the overhead is negligible; at scale, the per-field ciphertext expansion (up to ~48 bytes per field due to GCM tag and nonce) increases storage and bandwidth.
+- **No encryption for Android client:** The Android app (currently marked as outdated) does not implement the encryption flow. Users on Android would not be able to decrypt their data.
+
+## Reversibility
+
+- **Low.** The migration is destructive — it truncates all user data before altering columns. Reverting requires restoring from a pre-migration backup or re-populating data. The down-migration restores the schema but does not recover encrypted data.
+
+## Related Documents
+
+- [`SECURITY.md`](../SECURITY.md) – overall security design and principles
+- [`.kiro/specs/encryption-at-rest/design.md`](https://github.com/leocalm/piggy-pulse-api/blob/main/.kiro/specs/encryption-at-rest/design.md) – full design document
+- [`src/crypto.rs`](https://github.com/leocalm/piggy-pulse-api/blob/main/src/crypto.rs) – DEK and AES-GCM primitives
+- [`src/session_dek.rs`](https://github.com/leocalm/piggy-pulse-api/blob/main/src/session_dek.rs) – per-session DEK store
+- [`src/routes/v2/auth/unlock.rs`](https://github.com/leocalm/piggy-pulse-api/blob/main/src/routes/v2/auth/unlock.rs) – DEK unlock endpoint
+- [`migrations/20260327000008_encryption_at_rest.up.sql`](https://github.com/leocalm/piggy-pulse-api/blob/main/migrations/20260327000008_encryption_at_rest.up.sql) – schema migration


### PR DESCRIPTION
## Summary

Documents the encryption-at-rest design across the root repository:

- **ADR-010** — Architecture Decision Record for encryption-at-rest: AES-256-GCM, DEK/KEK key hierarchy, client-side encryption, encrypted columns across 7 tables
- **SECURITY.md** — New Encryption at Rest section covering the design, key protection, and limitations
- **ARCHITECTURE.md** — Updated system diagram to show the encryption layer
- **README.md** — Encryption added to key properties and security philosophy
- **AGENTS.md** — Encryption mentioned in backend tech stack, ADR-010 referenced

## Test plan

- [ ] Review each document for accuracy against the implementation in piggy-pulse-api, piggy-pulse-app, and piggy-pulse-ios
- [ ] Verify ADR-010 references match actual endpoints and migration files